### PR TITLE
Add deprecation note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# This project has been deprecated in favor of [Comunica's jQuery Widget fork](https://github.com/comunica/jQuery-Widget.js), which is part of the [Comunica](https://github.com/comunica/comunica) platform. It can do everything this jQuery-Widget.js can do, and more.
+
+-----
+
 # Linked Data Fragments jQuery Widget
 [<img src="http://linkeddatafragments.org/images/logo.svg" width="200" align="right" alt="" />](http://linkeddatafragments.org/)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# This project has been deprecated in favor of [Comunica's jQuery Widget fork](https://github.com/comunica/jQuery-Widget.js), which is part of the [Comunica](https://github.com/comunica/comunica) platform. It can do everything this jQuery-Widget.js can do, and more.
+# This project has been deprecated in favor of [Comunica's jQuery Widget](https://github.com/comunica/jQuery-Widget.js), which is part of the [Comunica](https://github.com/comunica/comunica) platform. It can do everything this jQuery-Widget.js can do, and more.
 
 -----
 


### PR DESCRIPTION
As discussed in https://github.com/LinkedDataFragments/jQuery-Widget.js/issues/13, this adds a deprecation note to the README.

Others things we need to do after merging this:
* Add a deprecation warning in the repo description.
* Remove it from the LDF website(?)
* Archive the GitHub repo.